### PR TITLE
fix: important imports for typing

### DIFF
--- a/src/spitch/_utils/_typing.py
+++ b/src/spitch/_utils/_typing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing_extensions, typing
 from typing import Any, TypeVar, Iterable, cast
 from collections import abc as _c_abc
 from typing_extensions import Required, Annotated, get_args, get_origin


### PR DESCRIPTION
fix: important imports for typing